### PR TITLE
NSQConsumer timing logic change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,19 @@
+
+organization := "com.github.brainlag"
+
+name := "JavaNSQClient"
+
+version := "1.0-MI"
+
+scalaVersion := "2.10.5"
+
+libraryDependencies ++= Seq(
+  "org.apache.logging.log4j" % "log4j-api" % "2.2",
+  "org.apache.logging.log4j" % "log4j-core" % "2.2",
+  "io.netty" % "netty-all" % "4.0.28.Final",
+  "io.netty" % "netty-tcnative" % "1.1.33.Fork2" % "test",
+  "org.apache.commons" % "commons-pool2" % "2.3",
+  "junit" % "junit" % "4.12" % "test",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.5.1",
+  "com.google.guava" % "guava" % "18.0"
+)

--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -13,10 +13,7 @@ import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class NSQConsumer {
@@ -27,8 +24,6 @@ public class NSQConsumer {
     private final NSQMessageCallback callback;
     private final NSQErrorCallback errorCallback;
     private final NSQConfig config;
-    private final Timer timer = new Timer();
-    private Timer timeout = new Timer();
     private volatile long nextTimeout = 0;
     private final Map<ServerAddress, Connection> connections = Maps.newHashMap();
     private final AtomicLong totalMessages = new AtomicLong(0l);
@@ -36,7 +31,9 @@ public class NSQConsumer {
     private boolean started = false;
     private int messagesPerBatch = 200;
     private long lookupPeriod = 60 * 1000; // how often to recheck for new nodes (and clean up non responsive nodes)
+    private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private ExecutorService executor = Executors.newCachedThreadPool();
+    private Optional<ScheduledFuture<?>> timeout = Optional.empty();
 
     public NSQConsumer(final NSQLookup lookup, final String topic, final String channel, final NSQMessageCallback callback) {
         this(lookup, topic, channel, callback, new NSQConfig());
@@ -63,17 +60,14 @@ public class NSQConsumer {
             started = true;
             //connect once otherwise we might have to wait one lookupPeriod
             connect();
-            timer.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    try {
-                        connect();
-                    } catch (Throwable t) {
-                        //dangerous but do nothing for now
-                        //The connect outside of this loop will throw an exception
-                    }
+            scheduler.scheduleAtFixedRate(() -> {
+                try {
+                    connect();
+                } catch (Throwable t) {
+                    //dangerous but do nothing for now
+                    //The connect outside of this loop will throw an exception
                 }
-            }, lookupPeriod, lookupPeriod);
+            }, lookupPeriod, lookupPeriod, TimeUnit.MILLISECONDS);
         }
         return this;
     }
@@ -119,16 +113,14 @@ public class NSQConsumer {
     private void updateTimeout(final NSQMessage message, long change) {
         rdy(message, 0);
         LogManager.getLogger(this).trace("RDY 0! Halt Flow.");
-        timeout.cancel();
+        if (timeout.isPresent()) {
+            timeout.get().cancel(true);
+        }
         Date newTimeout = calculateTimeoutDate(change);
         if (newTimeout != null) {
-            timeout = new Timer();
-            timeout.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    rdy(message, 1); // test the waters
-                }
-            }, newTimeout);
+            timeout = Optional.of(scheduler.schedule(() -> {
+                rdy(message, 1); // test the waters
+            }, 0, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -147,7 +139,7 @@ public class NSQConsumer {
     }
 
     public void shutdown() {
-        this.timer.cancel();
+        scheduler.shutdown();
         cleanClose();
     }
 
@@ -234,7 +226,30 @@ public class NSQConsumer {
         }
     }
 
-    public void scheduleRun(TimerTask task, int delay, int scheduleTime) {
-        timeout.schedule(task, delay, scheduleTime);
+    /**
+     * This method allows for a runnable task to be scheduled using the NSQConsumer's scheduler executor
+     * This is intended for calling a periodic method in a NSQMessageCallback for batching messages
+     * without needing state in the callback itself
+     *
+     * @param task The Runnable task
+     * @param delay Delay in milliseconds
+     * @param period Period of time between scheduled runs
+     * @param unit TimeUnit for delay and period times
+     * @return ScheduledFuture - useful for cancelling scheduled task
+     */
+    public ScheduledFuture scheduleRun(Runnable task, int delay, int period, TimeUnit unit) {
+        return scheduler.scheduleAtFixedRate(task, delay, period, unit);
+    }
+
+    /**
+     * Executor where scheduled callback methods are sent to
+     * @param scheduler scheduler to use (defaults to SingleThreadScheduledExecutor)
+     * @return this NSQConsumer
+     */
+    public NSQConsumer setScheduledExecutor(final ScheduledExecutorService scheduler) {
+        if (!started) {
+            this.scheduler = scheduler;
+        }
+        return this;
     }
 }

--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -233,4 +233,8 @@ public class NSQConsumer {
             throw Throwables.propagate(e);
         }
     }
+
+    public void scheduleRun(TimerTask task, int delay, int scheduleTime) {
+        timeout.schedule(task, delay, scheduleTime);
+    }
 }

--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -120,7 +120,7 @@ public class NSQConsumer {
         rdy(message, 0);
         LogManager.getLogger(this).trace("RDY 0! Halt Flow.");
         timeout.cancel();
-        Date newTimeout = caculateTimeoutDate(change);
+        Date newTimeout = calculateTimeoutDate(change);
         if (newTimeout != null) {
             timeout = new Timer();
             timeout.schedule(new TimerTask() {
@@ -136,7 +136,7 @@ public class NSQConsumer {
         message.getConnection().command(NSQCommand.instance("RDY " + size));
     }
 
-    private Date caculateTimeoutDate(final long i) {
+    private Date calculateTimeoutDate(final long i) {
         if (System.currentTimeMillis() - nextTimeout + i > 50) {
             nextTimeout += i;
             return new Date();

--- a/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
+++ b/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
 public class DefaultNSQLookup implements NSQLookup {
     Set<String> addresses = Sets.newHashSet();
 
@@ -26,16 +27,29 @@ public class DefaultNSQLookup implements NSQLookup {
         Set<ServerAddress> addresses = Sets.newHashSet();
 
         for (String addr : this.addresses) {
-            ObjectMapper mapper = new ObjectMapper();
+            try {
+                ObjectMapper mapper = new ObjectMapper();
 
-            JsonNode jsonNode = mapper.readTree(new URL(addr + "/lookup?topic=" + topic));
-            JsonNode producers = jsonNode.get("data").get("producers");
-            for (JsonNode node : producers) {
-                String host = node.get("broadcast_address").asText();
-                ServerAddress address = new ServerAddress(host, node.get("tcp_port").asInt());
-                addresses.add(address);
+                JsonNode jsonNode = mapper.readTree(new URL(addr + "/lookup?topic=" + topic));
+                LogManager.getLogger(this).warn("Server connection information: " + jsonNode.toString());
+                JsonNode producers = jsonNode.get("data").get("producers");
+                for (JsonNode node : producers) {
+                    String host = node.get("broadcast_address").asText();
+                    ServerAddress address = new ServerAddress(host, node.get("tcp_port").asInt());
+                    addresses.add(address);
+                }
+            } catch (IOException e) {
+                LogManager.getLogger(this).warn("Unable to connect to address " + addr);
             }
         }
+        if (addresses.isEmpty()) {
+            throw new IOException("Unable to connect to any NSQ Lookup servers, servers tried: " + this.addresses.toString());
+        } else {
+            return addresses;
+        }
+    }
+
+    public Set<String> getLookupAddresses() {
         return addresses;
     }
 }

--- a/src/test/java/com/github/brainlag/nsq/NSQProducerTest.java
+++ b/src/test/java/com/github/brainlag/nsq/NSQProducerTest.java
@@ -265,7 +265,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testMulitMessage() throws NSQException, TimeoutException, InterruptedException, IOException {
+    public void testMultiMessage() throws NSQException, TimeoutException, InterruptedException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -325,6 +325,21 @@ public class NSQProducerTest {
             Thread.sleep(500);
         }
         assertTrue(counter.get() >= 20);
+        consumer.shutdown();
+    }
+
+    @Test
+    public void testScheduledCallback() throws NSQException, TimeoutException, InterruptedException, IOException {
+        AtomicInteger counter = new AtomicInteger(0);
+        NSQLookup lookup = new DefaultNSQLookup();
+        lookup.addLookupAddress("localhost", 4161);
+
+        NSQConsumer consumer = new NSQConsumer(lookup, "test3", "testconsumer", (message) -> {});
+        consumer.scheduleRun(() -> counter.incrementAndGet(), 1000, 1000, TimeUnit.MILLISECONDS);
+        consumer.start();
+
+        Thread.sleep(1000);
+        assertTrue(counter.get() == 1);
         consumer.shutdown();
     }
 

--- a/src/test/java/com/github/brainlag/nsq/NSQProducerTest.java
+++ b/src/test/java/com/github/brainlag/nsq/NSQProducerTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.*;
@@ -61,7 +62,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testProduceOneMsgSnappy() throws NSQException, TimeoutException, InterruptedException {
+    public void testProduceOneMsgSnappy() throws NSQException, TimeoutException, InterruptedException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -88,7 +89,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testProduceOneMsgDeflate() throws NSQException, TimeoutException, InterruptedException {
+    public void testProduceOneMsgDeflate() throws NSQException, TimeoutException, InterruptedException, IOException {
         System.setProperty("io.netty.noJdkZlibDecoder", "false");
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
@@ -116,7 +117,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testProduceOneMsgSsl() throws InterruptedException, NSQException, TimeoutException, SSLException {
+    public void testProduceOneMsgSsl() throws InterruptedException, NSQException, TimeoutException, SSLException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -143,7 +144,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testProduceOneMsgSslAndSnappy() throws InterruptedException, NSQException, TimeoutException, SSLException {
+    public void testProduceOneMsgSslAndSnappy() throws InterruptedException, NSQException, TimeoutException, SSLException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -170,7 +171,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testProduceOneMsgSslAndDeflat() throws InterruptedException, NSQException, TimeoutException, SSLException {
+    public void testProduceOneMsgSslAndDeflat() throws InterruptedException, NSQException, TimeoutException, IOException {
         System.setProperty("io.netty.noJdkZlibDecoder", "false");
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
@@ -199,7 +200,7 @@ public class NSQProducerTest {
 
 
     @Test
-    public void testProduceMoreMsg() throws NSQException, TimeoutException, InterruptedException {
+    public void testProduceMoreMsg() throws NSQException, TimeoutException, InterruptedException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -228,7 +229,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testParallelProducer() throws NSQException, TimeoutException, InterruptedException {
+    public void testParallelProducer() throws NSQException, TimeoutException, InterruptedException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -264,7 +265,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testMulitMessage() throws NSQException, TimeoutException, InterruptedException {
+    public void testMulitMessage() throws NSQException, TimeoutException, InterruptedException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);
@@ -294,7 +295,7 @@ public class NSQProducerTest {
     }
 
     @Test
-    public void testBackoff() throws InterruptedException, NSQException, TimeoutException {
+    public void testBackoff() throws InterruptedException, NSQException, TimeoutException, IOException {
         AtomicInteger counter = new AtomicInteger(0);
         NSQLookup lookup = new DefaultNSQLookup();
         lookup.addLookupAddress("localhost", 4161);


### PR DESCRIPTION
- Changing repeatable tasks in NSQConsumer to use ScheduledThreadExecutor instead of Timer.

- Adding ability to schedule methods to use timer in NSQConsumer (useful for keeping NSQMessageCallback stateless and using NSQConsumer to flush)

These changes were useful for us for integrating NSQ with Scala and Spark.