### PR TITLE
Update the shutdown method 

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/NSQProducer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQProducer.java
@@ -173,6 +173,7 @@ public class NSQProducer {
     }
 
     public void shutdown() {
+        started = false;
         pool.close();
         executor.shutdown();
     }


### PR DESCRIPTION
Fixing the bug which can not restart the NSQProducer after shutdown, with changing the started status to false in shutdown method.