### PR TITLE
add some logs when lookup fails

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
+++ b/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Set;
+
 public class DefaultNSQLookup implements NSQLookup {
     Set<String> addresses = Sets.newHashSet();
 
@@ -40,12 +41,12 @@ public class DefaultNSQLookup implements NSQLookup {
                     addresses.add(address);
                 }
             } catch (IOException e) {
-                LogManager.getLogger(this).warn("Unable to connect to address {}", addr);
+                LogManager.getLogger(this).warn("Unable to connect to address {} for topic {}", addr, topic);
                 LogManager.getLogger(this).debug(e.getMessage());
             }
         }
         if (addresses.isEmpty()) {
-            LogManager.getLogger(this).warn("Unable to connect to any NSQ Lookup servers, servers tried: " + this.addresses.toString());
+            LogManager.getLogger(this).warn("Unable to connect to any NSQ Lookup servers, servers tried: {} on topic: {}", this.addresses, topic);
         }
         return addresses;
     }

--- a/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
+++ b/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
@@ -33,7 +33,7 @@ public class DefaultNSQLookup implements NSQLookup {
                 ObjectMapper mapper = new ObjectMapper();
                 String topicEncoded = URLEncoder.encode(topic, Charsets.UTF_8.name());
                 JsonNode jsonNode = mapper.readTree(new URL(addr + "/lookup?topic=" + topicEncoded));
-                LogManager.getLogger(this).debug("Server connection information: " + jsonNode.toString());
+                LogManager.getLogger(this).debug("Server connection information: {}", jsonNode);
                 JsonNode producers = jsonNode.get("data").get("producers");
                 for (JsonNode node : producers) {
                     String host = node.get("broadcast_address").asText();


### PR DESCRIPTION
When client tries to connect to a topic that doesn't exist, this message is logged:

`WARN  Unable to connect to any NSQ Lookup servers, servers tried: [http://xxxx:4161]`

It's difficult to identified if the problem is the nsqlookup configuration or if it's only a topic that doesn't exist yet.

So this pull request adds the topic in log message:

`WARN  Unable to connect to any NSQ Lookup servers, servers tried: [http://xxxxx:4161] on topic: my_funny_topic`
