### PR TITLE
Fix ByteBuf handling for newer versions of Netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.34.Final</version>
+      <version>4.0.39.Final</version>
     </dependency>
 
     <dependency>
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>1.1.33.Fork11</version>
+      <version>1.1.33.Fork18</version>
       <classifier>${os.detected.classifier}</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/com/github/brainlag/nsq/frames/MessageFrame.java
+++ b/src/main/java/com/github/brainlag/nsq/frames/MessageFrame.java
@@ -18,11 +18,12 @@ public class MessageFrame extends NSQFrame {
 		timestamp = buf.readLong();
 		attempts = buf.readShort();
 		buf.readBytes(messageId);
-		if (buf.hasArray()) {
-			messageBody = buf.readBytes(buf.readableBytes()).array();
+		ByteBuf messageBodyBuf = buf.readBytes(buf.readableBytes());
+		if (messageBodyBuf.hasArray()) {
+			messageBody = messageBodyBuf.array();
 		} else {
-			byte[] array = new byte[buf.readableBytes()];
-			buf.readBytes(array);
+			byte[] array = new byte[messageBodyBuf.readableBytes()];
+			messageBodyBuf.readBytes(array);
 			messageBody = array;
 		}
 	}

--- a/src/main/java/com/github/brainlag/nsq/frames/MessageFrame.java
+++ b/src/main/java/com/github/brainlag/nsq/frames/MessageFrame.java
@@ -18,7 +18,13 @@ public class MessageFrame extends NSQFrame {
 		timestamp = buf.readLong();
 		attempts = buf.readShort();
 		buf.readBytes(messageId);
-		messageBody = buf.readBytes(buf.readableBytes()).array();
+		if (buf.hasArray()) {
+			messageBody = buf.readBytes(buf.readableBytes()).array();
+		} else {
+			byte[] array = new byte[buf.readableBytes()];
+			buf.readBytes(array);
+			messageBody = array;
+		}
 	}
 	
 	public long getTimestamp() {

--- a/src/main/java/com/github/brainlag/nsq/netty/NSQDecoder.java
+++ b/src/main/java/com/github/brainlag/nsq/netty/NSQDecoder.java
@@ -26,7 +26,13 @@ public class NSQDecoder extends MessageToMessageDecoder<ByteBuf> {
 		}
 		frame.setSize(size);
 		ByteBuf bytes = in.readBytes(frame.getSize() - 4); //subtract 4 because the frame id is included
-		frame.setData(bytes.array());
+		if (bytes.hasArray()) {
+			frame.setData(bytes.array());
+		} else {
+			byte[] array = new byte[bytes.readableBytes()];
+			bytes.readBytes(array);
+			frame.setData(array);
+		}
 		out.add(frame);
 	}
 


### PR DESCRIPTION
Hi!

I've discovered that JavaNSQClient breaks for newer versions of Netty (from 4.0.37.Final onwards), due to how byte arrays are read from ByteBufs.

This pull request fixes the issue by checking to see if the ByteBuf supports direct array access, and falls back to reading into a pre-allocated byte array if direct access isn't supported. I've tested with NSQ v0.3.8.

Thanks,
Damien.