### PR TITLE
Refactor nsqcommand

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/Connection.java
+++ b/src/main/java/com/github/brainlag/nsq/Connection.java
@@ -68,8 +68,9 @@ public class Connection {
         channel.write(buf);
         channel.flush();
 
-        //indentify
-        final NSQCommand ident = NSQCommand.instance("IDENTIFY", config.toString().getBytes());
+        //identify
+        final NSQCommand ident = NSQCommand.identify(config.toString().getBytes());
+
         try {
             final NSQFrame response = commandAndWait(ident);
             if (response != null) {
@@ -147,7 +148,7 @@ public class Connection {
 
     private void heartbeat() {
         LogManager.getLogger(this).trace("HEARTBEAT!");
-        command(NSQCommand.instance("NOP"));
+        command(NSQCommand.nop());
         lastHeartbeatSuccess.getAndSet(System.currentTimeMillis());
     }
 

--- a/src/main/java/com/github/brainlag/nsq/NSQCommand.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQCommand.java
@@ -1,47 +1,121 @@
 package com.github.brainlag.nsq;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
 public class NSQCommand {
+    String line;
+    List<byte[]> data = new ArrayList<>();
 
-	public static NSQCommand instance(String line) {
-		NSQCommand n = new NSQCommand();
-		n.setLine(line);
-		return n;
-	}
-	
-	public static NSQCommand instance(String line, byte[] bytes) {
-		NSQCommand n = instance(line);
-		n.addBytes(bytes);
-		return n;
-	}
-	
-	String line;
-	List<byte[]> data = new ArrayList<>();
-	
-	public void addBytes(byte[] bytes) {
-		data.add(bytes);
-	}
-	
-	public String getLine() {
-		return line;
-	}
-	public void setLine(String line) {
-		if (!line.endsWith("\n")) {
-			line = line +"\n";
-		}
-		
-		this.line = line;
-	}
-	public List<byte[]> getData() {
-		return data;
-	}
-	public void setData(List<byte[]> data) {
-		this.data = data;
-	}
-	
-	public String toString() {
+    public void addBytes(byte[] bytes) {
+        data.add(bytes);
+    }
+
+    public String getLine() {
+        return line;
+    }
+
+    public void setLine(String line) {
+        if (!line.endsWith("\n")) {
+            line = line + "\n";
+        }
+
+        this.line = line;
+    }
+
+    public List<byte[]> getData() {
+        return data;
+    }
+
+    public void setData(List<byte[]> data) {
+        this.data = data;
+    }
+
+    public String toString() {
         return this.getLine().trim();
     }
+
+    // ASCII stores a reference to the charset needed for commands
+    public static final Charset ASCII = Charset.forName("ascii");
+
+    // Identify creates a new Command to provide information about the client.  After connecting,
+    // it is generally the first message sent.
+    //
+    // The supplied body should be a map marshaled into JSON to provide some flexibility
+    // for this command to evolve over time.
+    //
+    // See http://nsq.io/clients/tcp_protocol_spec.html#identify for information
+    // on the supported options
+    public static NSQCommand identify(byte[] body) {
+        return NSQCommand.instance("IDENTIFY", body);
+    }
+
+    // Touch creates a new Command to reset the timeout for
+    // a given message (by id)
+    public static NSQCommand touch(byte[] messageID) {
+        return NSQCommand.instance("TOUCH " + new String(messageID, ASCII));
+    }
+
+    // Finish creates a new Command to indiciate that
+    // a given message (by id) has been processed successfully
+    public static NSQCommand finish(byte[] messageID) {
+        return NSQCommand.instance("FIN " + new String(messageID, ASCII));
+    }
+
+    // Subscribe creates a new Command to subscribe to the given topic/channel
+    public static NSQCommand subscribe(String topic, String channel) {
+        return NSQCommand.instance("SUB " + topic + " " + channel);
+    }
+
+    // StartClose creates a new Command to indicate that the
+    // client would like to start a close cycle.  nsqd will no longer
+    // send messages to a client in this state and the client is expected
+    // finish pending messages and close the connection
+    public static NSQCommand startClose() {
+        return NSQCommand.instance("CLS");
+    }
+
+    public static NSQCommand requeue(byte[] messageID, int timeoutMillis) {
+        return NSQCommand.instance("REQ " + new String(messageID, ASCII) + " " + timeoutMillis);
+    }
+
+    // Nop creates a new Command that has no effect server side.
+    // Commonly used to respond to heartbeats
+    public static NSQCommand nop() {
+        return NSQCommand.instance("NOP");
+    }
+
+    // Ready creates a new Command to specify
+    // the number of messages a client is willing to receive
+    public static NSQCommand ready(int rdy) {
+        return NSQCommand.instance("RDY " + rdy);
+    }
+
+    // Publish creates a new Command to write a message to a given topic
+    public static NSQCommand publish(String topic, byte[] message) {
+        return NSQCommand.instance("PUB " + topic, message);
+    }
+
+    // MultiPublish creates a new Command to write more than one message to a given topic
+    // (useful for high-throughput situations to avoid roundtrips and saturate the pipe)
+    // Note: can only be used with more than 1 bodies!
+    public static NSQCommand multiPublish(String topic, List<byte[]> bodies) {
+        NSQCommand cmd = NSQCommand.instance("MPUB " + topic);
+        cmd.setData(bodies);
+        return cmd;
+    }
+
+    public static NSQCommand instance(String line) {
+        NSQCommand n = new NSQCommand();
+        n.setLine(line);
+        return n;
+    }
+
+    public static NSQCommand instance(String line, byte[] bytes) {
+        NSQCommand n = instance(line);
+        n.addBytes(bytes);
+        return n;
+    }
+
 }

--- a/src/main/java/com/github/brainlag/nsq/NSQCommand.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQCommand.java
@@ -8,6 +8,8 @@ public class NSQCommand {
     String line;
     List<byte[]> data = new ArrayList<>();
 
+    private NSQCommand() { /** no instances */ }
+
     public void addBytes(byte[] bytes) {
         data.add(bytes);
     }
@@ -106,13 +108,13 @@ public class NSQCommand {
         return cmd;
     }
 
-    public static NSQCommand instance(String line) {
+    private static NSQCommand instance(String line) {
         NSQCommand n = new NSQCommand();
         n.setLine(line);
         return n;
     }
 
-    public static NSQCommand instance(String line, byte[] bytes) {
+    private static NSQCommand instance(String line, byte[] bytes) {
         NSQCommand n = instance(line);
         n.addBytes(bytes);
         return n;

--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -83,8 +83,8 @@ public class NSQConsumer implements Closeable {
 
             connection.setConsumer(this);
             connection.setErrorCallback(errorCallback);
-            connection.command(NSQCommand.instance("SUB " + topic + " " + this.channel));
-            connection.command(NSQCommand.instance("RDY " + messagesPerBatch));
+            connection.command(NSQCommand.subscribe(topic, channel));
+            connection.command(NSQCommand.ready(messagesPerBatch));
 
             return connection;
         } catch (final NoConnectionsException e) {
@@ -131,7 +131,7 @@ public class NSQConsumer implements Closeable {
     }
 
     private void rdy(final NSQMessage message, int size) {
-        message.getConnection().command(NSQCommand.instance("RDY " + size));
+        message.getConnection().command(NSQCommand.ready(size));
     }
 
     private Date calculateTimeoutDate(final long i) {
@@ -150,7 +150,7 @@ public class NSQConsumer implements Closeable {
     }
 
     private void cleanClose() {
-        final NSQCommand command = NSQCommand.instance("CLS");
+        final NSQCommand command = NSQCommand.startClose();
         try {
             for (final Connection connection : connections.values()) {
                 final NSQFrame frame = connection.commandAndWait(command);

--- a/src/main/java/com/github/brainlag/nsq/NSQMessage.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQMessage.java
@@ -1,8 +1,5 @@
 package com.github.brainlag.nsq;
 
-import org.apache.logging.log4j.LogManager;
-
-import java.io.UnsupportedEncodingException;
 import java.util.Date;
 
 public class NSQMessage {
@@ -17,30 +14,18 @@ public class NSQMessage {
      * Finished processing this message, let nsq know so it doesnt get reprocessed.
      */
     public void finished() {
-        try {
-            connection.command(NSQCommand.instance("FIN " + new String(id, "ascii")));
-        } catch (UnsupportedEncodingException e) {
-            LogManager.getLogger(this).error("ASCII charset is not supported by your JVM?", e);
-        }
+        connection.command(NSQCommand.finish(this.id));
     }
 
     public void touch() {
-        try {
-            connection.command(NSQCommand.instance("TOUCH " + new String(id, "ascii")));
-        } catch (UnsupportedEncodingException e) {
-            LogManager.getLogger(this).error("ASCII charset is not supported by your JVM?", e);
-        }
+        connection.command(NSQCommand.touch(this.id));
     }
 
     /**
      * indicates a problem with processing, puts it back on the queue.
      */
     public void requeue(int timeoutMillis) {
-        try {
-            connection.command(NSQCommand.instance("REQ " + new String(id, "ascii") + " " + timeoutMillis));
-        } catch (UnsupportedEncodingException e) {
-            LogManager.getLogger(this).error("ASCII charset is not supported by your JVM?", e);
-        }
+        connection.command(NSQCommand.requeue(this.id, timeoutMillis));
     }
 
     public void requeue() {

--- a/src/main/java/com/github/brainlag/nsq/NSQProducer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQProducer.java
@@ -85,8 +85,7 @@ public class NSQProducer {
 
         Connection c = this.getConnection();
         try {
-            NSQCommand command = NSQCommand.instance("MPUB " + topic);
-            command.setData(messages);
+            NSQCommand command = NSQCommand.multiPublish(topic, messages);
 
 
             NSQFrame frame = c.commandAndWait(command);
@@ -110,7 +109,7 @@ public class NSQProducer {
         }
         Connection c = getConnection();
         try {
-            NSQCommand command = NSQCommand.instance("PUB " + topic, message);
+            NSQCommand command = NSQCommand.publish(topic, message);
             NSQFrame frame = c.commandAndWait(command);
             if (frame != null && frame instanceof ErrorFrame) {
                 String err = ((ErrorFrame) frame).getErrorMessage();

--- a/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
+++ b/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
@@ -14,6 +14,15 @@ import java.util.Set;
 
 public class DefaultNSQLookup implements NSQLookup {
     Set<String> addresses = Sets.newHashSet();
+    private final ObjectMapper mapper;
+
+    public DefaultNSQLookup() {
+        this(new ObjectMapper());
+    }
+
+    public DefaultNSQLookup(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     @Override
     public void addLookupAddress(String addr, int port) {
@@ -30,7 +39,6 @@ public class DefaultNSQLookup implements NSQLookup {
 
         for (String addr : getLookupAddresses()) {
             try {
-                ObjectMapper mapper = new ObjectMapper();
                 String topicEncoded = URLEncoder.encode(topic, Charsets.UTF_8.name());
                 JsonNode jsonNode = mapper.readTree(new URL(addr + "/lookup?topic=" + topicEncoded));
                 LogManager.getLogger(this).debug("Server connection information: {}", jsonNode);

--- a/src/main/java/com/github/brainlag/nsq/pool/ConnectionPoolFactory.java
+++ b/src/main/java/com/github/brainlag/nsq/pool/ConnectionPoolFactory.java
@@ -30,7 +30,7 @@ public class ConnectionPoolFactory extends BaseKeyedPooledObjectFactory<ServerAd
 
     @Override
     public boolean validateObject(final ServerAddress key, final PooledObject<Connection> p) {
-        ChannelFuture command = p.getObject().command(NSQCommand.instance("NOP"));
+        ChannelFuture command = p.getObject().command(NSQCommand.nop());
         return command.awaitUninterruptibly().isSuccess();
     }
 

--- a/src/test/java/com/github/brainlag/nsq/NSQConsumerTest.java
+++ b/src/test/java/com/github/brainlag/nsq/NSQConsumerTest.java
@@ -21,7 +21,7 @@ public class NSQConsumerTest {
     @Test
     public void testLongRunningConsumer() throws NSQException, TimeoutException, InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQConsumer consumer = new NSQConsumer(lookup, "test1", "testconsumer", (message) -> {

--- a/src/test/java/com/github/brainlag/nsq/NSQProducerTest.java
+++ b/src/test/java/com/github/brainlag/nsq/NSQProducerTest.java
@@ -1,5 +1,6 @@
 package com.github.brainlag.nsq;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.brainlag.nsq.exceptions.NSQException;
 import com.github.brainlag.nsq.lookup.DefaultNSQLookup;
 import com.github.brainlag.nsq.lookup.NSQLookup;
@@ -27,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class NSQProducerTest {
+    private ObjectMapper mapper = new ObjectMapper();
 
     private NSQConfig getSnappyConfig() {
         final NSQConfig config = new NSQConfig();
@@ -68,7 +70,7 @@ public class NSQProducerTest {
     @Test
     public void testProduceOneMsgSnappy() throws NSQException, TimeoutException, InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQProducer producer = new NSQProducer();
@@ -96,7 +98,7 @@ public class NSQProducerTest {
     public void testProduceOneMsgDeflate() throws NSQException, TimeoutException, InterruptedException {
         System.setProperty("io.netty.noJdkZlibDecoder", "false");
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQProducer producer = new NSQProducer();
@@ -123,7 +125,7 @@ public class NSQProducerTest {
     @Test
     public void testProduceOneMsgSsl() throws InterruptedException, NSQException, TimeoutException, SSLException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQProducer producer = new NSQProducer();
@@ -150,7 +152,7 @@ public class NSQProducerTest {
     @Test
     public void testProduceOneMsgSslAndSnappy() throws InterruptedException, NSQException, TimeoutException, SSLException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQProducer producer = new NSQProducer();
@@ -178,7 +180,7 @@ public class NSQProducerTest {
     public void testProduceOneMsgSslAndDeflat() throws InterruptedException, NSQException, TimeoutException, SSLException {
         System.setProperty("io.netty.noJdkZlibDecoder", "false");
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQProducer producer = new NSQProducer();
@@ -206,7 +208,7 @@ public class NSQProducerTest {
     @Test
     public void testProduceMoreMsg() throws NSQException, TimeoutException, InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQConsumer consumer = new NSQConsumer(lookup, "test3", "testconsumer", (message) -> {
@@ -235,7 +237,7 @@ public class NSQProducerTest {
     @Test
     public void testParallelProducer() throws NSQException, TimeoutException, InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQConsumer consumer = new NSQConsumer(lookup, "test3", "testconsumer", (message) -> {
@@ -271,7 +273,7 @@ public class NSQProducerTest {
     @Test
     public void testMultiMessage() throws NSQException, TimeoutException, InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQConsumer consumer = new NSQConsumer(lookup, "test3", "testconsumer", (message) -> {
@@ -301,7 +303,7 @@ public class NSQProducerTest {
     @Test
     public void testBackoff() throws InterruptedException, NSQException, TimeoutException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQConsumer consumer = new NSQConsumer(lookup, "test3", "testconsumer", (message) -> {
@@ -335,7 +337,7 @@ public class NSQProducerTest {
     @Test
     public void testScheduledCallback() throws NSQException, TimeoutException, InterruptedException {
         AtomicInteger counter = new AtomicInteger(0);
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQConsumer consumer = new NSQConsumer(lookup, "test3", "testconsumer", (message) -> {});
@@ -349,7 +351,7 @@ public class NSQProducerTest {
 
     @Test
     public void testEphemeralTopic() throws InterruptedException, NSQException, TimeoutException {
-        NSQLookup lookup = new DefaultNSQLookup();
+        NSQLookup lookup = new DefaultNSQLookup(mapper);
         lookup.addLookupAddress(Nsq.getNsqLookupdHost(), 4161);
 
         NSQProducer producer = new NSQProducer();


### PR DESCRIPTION
Preparing for some further additions to flow control (RDY count in this NSQ client).

This PR does:

1. refactor `NSQCommand` to constructor methods and cleans up some error handling of creating commands.
2. Make it harder to create invalid commands by providing creator functions.
3. DefaultNSQLookup: accept an ObjectMapper
    - The recommended way to use ObjectMapper is to have a shared instance in
your application.

