### PR TITLE
37: compatibility with NSQ v1.0.0-compact

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
+++ b/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
@@ -42,7 +42,7 @@ public class DefaultNSQLookup implements NSQLookup {
                 String topicEncoded = URLEncoder.encode(topic, Charsets.UTF_8.name());
                 JsonNode jsonNode = mapper.readTree(new URL(addr + "/lookup?topic=" + topicEncoded));
                 LogManager.getLogger(this).debug("Server connection information: {}", jsonNode);
-                JsonNode producers = jsonNode.get("data").get("producers");
+                JsonNode producers = jsonNode.findValue("producers");
                 for (JsonNode node : producers) {
                     String host = node.get("broadcast_address").asText();
                     ServerAddress address = new ServerAddress(host, node.get("tcp_port").asInt());


### PR DESCRIPTION
37: accommodate changes in nsq v1.0.0-compact, also provided backward compatibility

Api call for discovery (/lookup?topic=XXX) has been changed in NSQ v1.0.0-compact (although they've not updated their webpage yet)

`Response in NSQ prior to v1.0.0-compact
{
status_code: 200,
status_txt: "OK",
data: {
channels: [ ],
producers: [
{
remote_address: "127.0.0.1:39310",
hostname: "vikash.tiwari",
broadcast_address: "vikash.tiwari",
tcp_port: 4150,
http_port: 4151,
version: "0.3.8"
}
]
}
}`

`Response in NSQ v1.0.0-compact
{
channels: [
"emailChannel"
],
producers: [
{
remote_address: "127.0.0.1:40258",
hostname: "vikash.tiwari",
broadcast_address: "vikash.tiwari",
tcp_port: 4150,
http_port: 4151,
version: "1.0.0-compat"
}
]
}
`

I have also created the documentation issue [https://github.com/nsqio/nsq/issues/870](https://github.com/nsqio/nsq/issues/870)