### PR TITLE
Update connection logic to prevent errors

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorCallback.java
+++ b/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorCallback.java
@@ -1,0 +1,17 @@
+package com.github.brainlag.nsq.callbacks;
+
+import java.io.IOException;
+
+/**
+ * Functional interface for handling errors encountered during the connection phase.
+ *
+ * This allows one to listen for exceptions in the `NSQConsumer#connect` operations and react
+ * in an appropriate way, including raising exceptions of its own. If an exception is raised, it
+ * must be of type IOException
+ *
+ * @author Josh Wickham
+ */
+@FunctionalInterface
+public interface ConnectErrorCallback {
+    void error(Exception e);
+}


### PR DESCRIPTION
Use ImmutableSet and Iterators to prevent ConcurrentModificationExceptions.
Introduce a ConnectErrorHandler so users of this library can handle any
errors encountered during connection instead of having the errors just
get swallowed in a different thread which causes the connection timer to
fail and eventually lose servers during autoscaling.