### PR TITLE
close connection after consumer close

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -158,6 +158,7 @@ public class NSQConsumer implements Closeable {
                         throw new IllegalStateException(err);
                     }
                 }
+                connection.close();
             }
         } catch (final TimeoutException e) {
             LogManager.getLogger(this).warn("No clean disconnect", e);


### PR DESCRIPTION
when call NsqConsumer.close(), the consumer is down, but the connection between consumer and nsq is still connected. so we can call connection.close() after receive CLS reply in cleanClose.